### PR TITLE
Rescale the PDF to fit in the current viewport width.

### DIFF
--- a/ui/public/index.html
+++ b/ui/public/index.html
@@ -3,7 +3,7 @@
     <meta charset="utf-8">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <title>Skiff Template</title>
+    <title>PAWLS</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/ui/src/components/PDF.tsx
+++ b/ui/src/components/PDF.tsx
@@ -1,71 +1,131 @@
 import React, { useRef, useEffect, useState }  from 'react';
-import { PDFPageProxy, PDFDocumentProxy } from 'pdfjs-dist';
+import { PDFPageProxy, PDFDocumentProxy, PDFRenderTask } from 'pdfjs-dist';
 import { Result } from '@allenai/varnish';
 
-enum ViewState {
-    INITIALIZING, INITIALIZED, RENDERED, ERROR
+class PDFPageRenderer {
+    private currentRenderTask?: PDFRenderTask;
+    constructor(
+        readonly page: PDFPageProxy,
+        readonly canvas: HTMLCanvasElement | null,
+    ) {}
+    cancelCurrentRender(onError: (e: Error) => void) {
+        if (this.currentRenderTask === undefined) {
+            return;
+        }
+        this.currentRenderTask.promise.then(
+            () => {},
+            (err: any) => {
+                if (err instanceof Error) {
+                    if (err.name !== 'RenderingCancelledException') {
+                        onError(err);
+                    }
+                } else {
+                    onError(new Error(err));
+                }
+            }
+        );
+        this.currentRenderTask.cancel();
+    }
+    render() {
+        if (this.canvas === null) {
+            throw new Error('No canvas');
+        }
+        if (this.canvas.parentElement === null) {
+            throw new Error('The canvas element has no parent');
+        }
+        const width = this.page.view[2] - this.page.view[1];
+
+        // Scale it so the user doesn't have to scroll horizontally
+        const scale = Math.max(this.canvas.parentElement.clientWidth / width);
+
+        const viewport = this.page.getViewport({ scale });
+        this.canvas.height = viewport.height;
+        this.canvas.width = viewport.width;
+
+        const canvasContext = this.canvas.getContext('2d');
+        if (canvasContext === null) {
+            throw new Error('No canvas context');
+        }
+        this.currentRenderTask = this.page.render({ canvasContext, viewport });
+        return this.currentRenderTask;
+    }
+    rescaleAndRender(onError: (e: Error) => void) {
+        this.cancelCurrentRender(onError);
+        return this.render();
+    }
 }
 
-export const PDF = ({ doc, page }: { doc: PDFDocumentProxy, page?: number }) => {
-    const [ viewState, setViewState ] = useState<ViewState>(ViewState.INITIALIZING);
+interface WithErrorCallback {
+    onError: (e: Error) => void;
+}
+
+interface PageProps extends WithErrorCallback {
+    page: PDFPageProxy;
+}
+
+const Page = ({ page, onError }: PageProps) => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
+
+    useEffect(() => {
+        try {
+            const renderer = new PDFPageRenderer(page, canvasRef.current);
+            renderer.render();
+
+            const rescalePdf = () => { renderer.rescaleAndRender(onError) };
+            window.addEventListener('resize', rescalePdf);
+            return () => { window.removeEventListener('resize', rescalePdf) };
+        } catch (e) {
+            onError(e);
+        }
+    }, [ page, onError ]);
+
+    return <canvas ref={canvasRef} />;
+};
+
+interface PDFProps {
+    doc: PDFDocumentProxy;
+    page?: number;
+}
+
+interface WithPageProps extends PDFProps, WithErrorCallback {
+    children: (page: PDFPageProxy) => React.ReactNode;
+}
+
+const WithPage = ({ doc, page, onError, children }: WithPageProps) => {
+    const [ pdfPage, setPdfPage ] = useState<PDFPageProxy>();
     const pageNo = page || 1;
 
     useEffect(() => {
         doc.getPage(pageNo).then(
             (page: PDFPageProxy) => {
-                setViewState(ViewState.INITIALIZED);
-                const canvas = canvasRef.current;
-                if (canvas === null) {
-                    console.error('Error: No canvas element.');
-                    setViewState(ViewState.ERROR);
-                    return;
-                }
-                if (canvas.parentElement === null) {
-                    console.error('Error: The canvas element does not have a valid parent element.');
-                    setViewState(ViewState.ERROR);
-                    return;
-                }
-                // Calculate the width of the document.
-                // See: https://github.com/mozilla/pdf.js/blob/7edc5cb79fe829d45fed85e2b4b6d8594522cc10/src/display/api.js#L1039
-                const width = page.view[2] - page.view[1];
-
-                // Scale it so the user doesn't have to scroll horizontally
-                const scale = Math.max(canvas.parentElement.clientWidth / width);
-
-                // TODO (@codeviking): Add an event listener for adjusting the canvas dimensions and
-                // the viewport scale when the window is resized.
-                const viewport = page.getViewport({ scale });
-                canvas.height = viewport.height;
-                canvas.width = viewport.width;
-
-                const canvasContext = canvas.getContext('2d');
-                if (canvasContext === null) {
-                    console.error('Error: No valid canvas context.');
-                    setViewState(ViewState.ERROR);
-                    return;
-                }
-                page.render({
-                    canvasContext,
-                    viewport: viewport
-                });
-
-                setViewState(ViewState.RENDERED);
+                setPdfPage(page);
             },
             reason => {
-                console.error(`Error rendering PDF: `, reason);
-                setViewState(ViewState.ERROR);
+                onError(new Error(reason));
             }
         );
-    }, [ doc, pageNo ]);
+    }, [ doc, pageNo, onError ]);
 
+    // TODO (@codeviking): The `getPage()` call above returns fast enough that we don't have
+    // any type of interstitial display here. We probably should put one in place for slower
+    // clients.
+    return pdfPage ? <>{children(pdfPage)}</> : null;
+};
+
+export const PDF = (props: PDFProps) => {
+    const [ err, setError ] = useState<Error>();
+    if (err) {
+        console.error(`Error rendering PDF: `, err);
+    }
     return (
-        viewState === ViewState.ERROR ? (
+        err ? (
             <Result
                 status="warning"
-                title="Error Rendering PDF" />
+                title="Unable to Render PDF" />
         ) : (
-            <canvas ref={canvasRef} />
+            <WithPage {...{...props, onError: setError }}>
+                {p => <Page page={p} onError={setError} />}
+            </WithPage>
         )
     );
 };

--- a/ui/src/pages/PDFPage.tsx
+++ b/ui/src/pages/PDFPage.tsx
@@ -50,8 +50,7 @@ export const PDFPage = () => {
             },
             (reason: any) => {
                 if (reason instanceof Error) {
-                    const err: Error = reason;
-                    if (err.name === 'MissingPDFException') {
+                    if (reason.name === 'MissingPDFException') {
                         setViewState(ViewState.NOT_FOUND);
                         return;
                     }
@@ -117,12 +116,13 @@ export const PDFPage = () => {
                                 )}
                             </PageNav>
                         </Sidebar>
-                        <CenterOnPage>
+                        <PDFContainer>
                             <PDF doc={doc} page={currentPage} />
-                        </CenterOnPage>
+                        </PDFContainer>
                     </WithSidebar>
                 );
             }
+        // eslint-disable-line: no-fallthrough
         case ViewState.ERROR:
             return (
                 <CenterOnPage>
@@ -161,3 +161,6 @@ const DisabledPageLink = styled.span`
     color: rgba(255, 255, 255, 0.5);
 `;
 
+const PDFContainer = styled.div`
+    overflow: scroll;
+`


### PR DESCRIPTION
This makes changes that allow the PDF to be rescaled to fit the
viewport width.

At smaller resolutions it becomes unreadable, so there's probably
a minimum we'll eventually set. That said we can fry that fish later --
this just gets the code in place so that it doesn't conflict with
the other changes enroute.