### PR TITLE
Store bounds

### DIFF
--- a/ui/src/context/AnnotationStore.ts
+++ b/ui/src/context/AnnotationStore.ts
@@ -6,22 +6,22 @@ export interface TokenId {
     tokenIndex: number;
 }
 
-export interface TokenSpanAnnotation {
-    tokens: TokenId[]
-    bounds: Bounds[]
-    pages: number[]
-};
+export class TokenSpanAnnotation {
+    constructor(
+        public readonly tokens: TokenId[],
+        public readonly bounds: Bounds[],
+        public readonly pages: number[]
+    ) {}
 
-
-export function merge(a: TokenSpanAnnotation, b: TokenSpanAnnotation): TokenSpanAnnotation {
-
-    const newTokens = a.tokens.concat(b.tokens)
-    return {
-        tokens: newTokens,
-        bounds: a.bounds.concat(b.bounds),
-        pages: a.pages.concat(b.pages)
+    mergeWith(a: TokenSpanAnnotation): TokenSpanAnnotation {
+        return new TokenSpanAnnotation(
+            this.tokens.concat(a.tokens),
+            this.bounds.concat(a.bounds),
+            this.pages.concat(a.pages)
+        )
     }
-}
+
+};
 
 
 interface _AnnotationStore {

--- a/ui/src/context/PDFStore.ts
+++ b/ui/src/context/PDFStore.ts
@@ -39,7 +39,7 @@ function relativeTo(a: Bounds, b: Bounds): Bounds {
 /**
  * Computes a bound which contains all of the bounds passed as arguments.
  */
-function spanningBound(bounds: Bounds[], padding: number = 10): Bounds{
+function spanningBound(bounds: Bounds[], padding: number = 5): Bounds{
 
     // Start with a bounding box for which any bound would be
     // contained within, meaning we immediately update maxBound.
@@ -130,11 +130,7 @@ export class PDFPageInfo {
             }
         }
         const bounds = spanningBound(tokenBounds)
-        return {
-            tokens: ids,
-            bounds: [bounds],
-            pages: [this.page.pageNumber - 1]
-        }
+        return new TokenSpanAnnotation(ids, [bounds], [this.page.pageNumber - 1])
     }
 
     getIntersectingTokens(selection: Bounds): Token[] {


### PR DESCRIPTION
- `TokenId => TokenWithId` which inherits from `Token`, so we can keep the token info around
- Add some functions to get a padded bounding box for a set of tokens
- render the `Bounds` of the currently selected annotation as well as the tokens.

This all works great, with one tricky thing: The maximum spanning Bound is computed with respect to a given pages' scale. So if the user re-sizes the page, the bounds are the wrong scale. I tried handling this by passing the `selection` into the `Page`, so that we can transform the bounds using the `PageInfo.scale` before rendering, like we do for tokens, but this has two problems:


1. The scaling had some odd side effect (the box was offset slightly from the tokens)
2. The maximum spanning `Bounds` of all of the tokens could potentially cross page boundaries.


_edit: I think the weird offset was because I wasn't calling `relativeTo` the newly rescaled pdf bounds when I was rescaling the bounding box. Let me try that._