### PR TITLE
refactor selection

### DIFF
--- a/ui/src/components/Selection.tsx
+++ b/ui/src/components/Selection.tsx
@@ -1,17 +1,9 @@
 import React, { useContext } from 'react';
 import styled, { ThemeContext } from 'styled-components';
 
-import { Bounds } from '../context';
+import { Bounds, TokenId, PDFPageInfo } from '../context';
 import { Label } from '../api'
 import { CloseCircleFilled } from '@ant-design/icons';
-
-interface SelectionProps {
-    bounds: Bounds
-    isActiveSelection: boolean
-    label?: Label
-    onClickDelete?: () => void
-
- }
 
  function hexToRgb(hex: string) {
     var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
@@ -26,8 +18,88 @@ interface SelectionProps {
   }
   
 
+interface SelectionBoundaryProps {
+    color: string
+    bounds: Bounds
+    children?: React.ReactNode
+}
 
-export const Selection = ({ bounds, label, isActiveSelection, onClickDelete }: SelectionProps) => {
+export const SelectionBoundary = ({color, bounds, children}: SelectionBoundaryProps) => {
+    const width = bounds.right - bounds.left;
+    const height = bounds.bottom - bounds.top;
+    const rotateY = width < 0 ? -180 : 0;
+    const rotateX = height < 0 ? -180 : 0;
+    const border = 3
+    const rgbColor = hexToRgb(color)
+
+    return (
+        <span
+          style={{
+            position: "absolute",
+            left: `${bounds.left}px`,
+            top: `${bounds.top}px`,
+            width: `${Math.abs(width)}px`,
+            height: `${Math.abs(height)}px`,
+            transform: `rotateY(${rotateY}deg) rotateX(${rotateX}deg)`,
+            transformOrigin: 'top left',
+            border: `${border}px solid ${color}`,
+            background: `rgba(${rgbColor.r}, ${rgbColor.g}, ${rgbColor.b}, 0.1)`,
+        }}
+        >
+            {children ? children: null}
+        </span>
+    )
+}
+
+
+interface TokenSpanProps {
+    isSelected?: boolean;
+}
+
+const TokenSpan = styled.span<TokenSpanProps>(({ theme, isSelected }) =>`
+    position: absolute;
+    background: ${isSelected ? theme.color.B6 : 'none'};
+    opacity: 0.2;
+    border-radius: 3px;
+`);
+
+interface SelectionTokenProps {
+    pageInfo: PDFPageInfo
+    tokens: TokenId[]
+}
+export const SelectionTokens = ({pageInfo, tokens}: SelectionTokenProps) => {
+
+    return (
+        <>
+        {tokens && tokens.map((t, i) => {
+            const b = pageInfo.getScaledTokenBounds(pageInfo.tokens[t.tokenIndex]);
+            return (
+                <TokenSpan
+                    key={i}
+                    isSelected={true}
+                    style={{
+                        left: `${b.left}px`,
+                        top: `${b.top}px`,
+                        width: `${b.right - b.left}px`,
+                        height: `${b.bottom - b.top}px`
+                    }} />
+                )
+
+          })}
+        </>
+    )
+}
+
+interface SelectionProps {
+    pageInfo: PDFPageInfo
+    bounds: Bounds
+    tokens?: TokenId[]
+    label: Label
+    onClickDelete?: () => void
+
+ }
+
+export const Selection = ({ pageInfo, tokens, bounds, label, onClickDelete }: SelectionProps) => {
     const theme = useContext(ThemeContext)
     let color;
     if (!label) {
@@ -35,50 +107,39 @@ export const Selection = ({ bounds, label, isActiveSelection, onClickDelete }: S
     } else {
         color = label.color
     }
-
-    const width = bounds.right - bounds.left;
-    const height = bounds.bottom - bounds.top;
-    const rotateY = width < 0 ? -180 : 0;
-    const rotateX = height < 0 ? -180 : 0;
     const border = 3
 
-    const rgbColor = hexToRgb(color)
-
     return (
-         <span
-            style={{
-                position: "absolute",
-                left: `${bounds.left}px`,
-                top: `${bounds.top}px`,
-                width: `${Math.abs(width)}px`,
-                height: `${Math.abs(height)}px`,
-                transform: `rotateY(${rotateY}deg) rotateX(${rotateX}deg)`,
-                transformOrigin: 'top left',
-                border: `${border}px solid ${color}`,
-                background: `rgba(${rgbColor.r}, ${rgbColor.g}, ${rgbColor.b}, 0.1)`,
-            }}
-            >
-              {label && !isActiveSelection ? (
-                 <SelectionInfo border={border} color={color}>
-                    <span>
-                     {label.text}
-                   </span>
-                   <CloseCircleFilled
-                      onClick={(e) => {
-                          e.stopPropagation();
-                          if (onClickDelete){
-                              onClickDelete()
-                          }
-                      }}
-                      // We have to prevent the default behaviour for
-                      // the pdf canvas here, in order to be able to capture
-                      // the click event.
-                      onMouseDown={(e) => {e.stopPropagation()}}
-                      onMouseUp={(e) => {e.stopPropagation()}}
-                   />
-                 </SelectionInfo>
-                ): null}
-         </span>
+        <>
+          <SelectionBoundary color={color} bounds={bounds}>
+            <SelectionInfo border={border} color={color}>
+              <span>
+                {label.text}
+              </span>
+            <CloseCircleFilled
+              onClick={(e) => {
+                  e.stopPropagation();
+                  if (onClickDelete){
+                      onClickDelete()
+                  }
+              }}
+              // We have to prevent the default behaviour for
+              // the pdf canvas here, in order to be able to capture
+              // the click event.
+              onMouseDown={(e) => {e.stopPropagation()}}
+              onMouseUp={(e) => {e.stopPropagation()}}
+            />
+            </SelectionInfo>
+          </SelectionBoundary>
+          { 
+            // NOTE: It's important that the parent element of the tokens
+            // is the PDF canvas, because we need their absolute position
+            // to be relative to that and not another absolute/relatively
+            // positioned element. This is why SelectionTokens are not inside
+            // SelectionBoundary.
+            tokens ? <SelectionTokens pageInfo={pageInfo} tokens={tokens}/>: null
+          }
+        </>
      );
  }
 


### PR DESCRIPTION
- Compose `Selection` of two components, `SelectionBoundary` and `SelectionTokens`
- `SelectionBoundary` is then used to render the active bounding box the user is drawing, and we pass the tokens it covers to `Page` as `extraTokens`, which we render with `SelectionTokens`.

Not ideal: this assumes that each `Annotation` as strictly one `Bounds` per page, which is currently true, but it makes using an array for this a bit weird. However, using a map for this would exclude the possibility of using multiple annotations per page - but I think we should do it anyway, because we don't have a use case for that yet.