### PR TITLE
Use Google login instead of AI2 login

### DIFF
--- a/.skiff/webapp.jsonnet
+++ b/.skiff/webapp.jsonnet
@@ -115,8 +115,8 @@ function(
                 'cert-manager.io/cluster-issuer': 'letsencrypt-prod',
                 'kubernetes.io/ingress.class': 'nginx',
                 'nginx.ingress.kubernetes.io/ssl-redirect': 'true',
-                'nginx.ingress.kubernetes.io/auth-url': 'https://ai2-login.apps.allenai.org/oauth2/auth',
-                'nginx.ingress.kubernetes.io/auth-signin': 'https://ai2-login.apps.allenai.org/oauth2/start?rd=https://$host$request_uri',
+                'nginx.ingress.kubernetes.io/auth-url': 'https://google.login.apps.allenai.org/oauth2/auth',
+                'nginx.ingress.kubernetes.io/auth-signin': 'https://google.login.apps.allenai.org/oauth2/start?rd=https://$host$request_uri',
                 'nginx.ingress.kubernetes.io/auth-response-headers': 'X-Auth-Request-User, X-Auth-Request-Email'
             }
         },


### PR DESCRIPTION
Now that we have authz, we can flip to the broader Google authn.