### PR TITLE
error message for 403

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -10,7 +10,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { createGlobalStyle } from 'styled-components';
-import { Spin } from "@allenai/varnish";
+import { Spin, Result } from "@allenai/varnish";
 import { BrowserRouter, Route, Redirect} from 'react-router-dom';
 
 import { PDFPage } from './pages';
@@ -20,20 +20,45 @@ import { getAllocatedPaperStatus } from "./api"
 
 const RedirectToFirstPaper = () => {
     const [sha, setSha] = useState<string>();
+    const [authenticated, setAuthenticated] = useState<boolean>(true);
     useEffect(() => {
         getAllocatedPaperStatus().then((allocation) => {
             const first = allocation.papers[0]
             setSha(first.sha)
+        }).catch((err) => {
+            setAuthenticated(false)
         })
     },[])
 
-    return sha ? <Redirect to={`/pdf/${sha}`} /> : (
-        <CenterOnPage>
-            <Spin size="large"/>
-        </CenterOnPage>
-    )
-}
+    if (!sha && authenticated) {
+        return (
+            <CenterOnPage>
+                <Spin size="large"/>
+            </CenterOnPage>
+        )
+    }
+    else if (!sha && !authenticated) {
+        return ( 
 
+            <CenterOnPage>
+                <Result
+                    status="403"
+                    title="403"
+                    subTitle={
+                        <p>
+                            Sorry, you are not authorized to access this page.
+                            If you believe you should have access, please try logging out 
+                            <a href="https://google.login.apps.allenai.org/oauth2/sign_out"> here </a>
+                            and reloading this page.
+                        </p>
+                        }
+                />
+            </CenterOnPage>
+        )}
+    else {
+        return <Redirect to={`/pdf/${sha}`} /> 
+    }
+}
 
 const App = () => {
     return (


### PR DESCRIPTION

Looks like this:
![Screen Shot 2021-01-07 at 11 41 01 AM](https://user-images.githubusercontent.com/16001974/103937245-580a5a00-50dd-11eb-9479-a205e5a00199.png)


@codeviking - This isn't very comprehensive because if someone goes directly to a pdf url, this wouldn't appear. Any advice you have on how to do this better would be much appreciated - capturing the errors from all of the different routes which might 403 seems quite hard somehow, but there must be a reasonable way to address this that I don't know about.... I guess I can just add a new view state of `UNAUTHORIZED` or something? 

