### PR TITLE
Improve accuracy calculation and export functions 

### DIFF
--- a/cli/pawls/commands/export.py
+++ b/cli/pawls/commands/export.py
@@ -384,7 +384,9 @@ def export(
     if len(categories) == 0:
         categories = config.categories
         print(f"Export annotations from all available categories {categories}")
-
+    else:
+        print(f"Export annotations from the following categories {categories}")
+        
     if format == "coco":
 
         coco_builder = COCOBuilder(categories, output)

--- a/cli/pawls/commands/export.py
+++ b/cli/pawls/commands/export.py
@@ -25,17 +25,19 @@ def _convert_bounds_to_coco_bbox(bounds: Dict[str, Union[int, float]]):
     return x1, y1, x2 - x1, y2 - y1
 
 
-def try_find_tokens_in_anno_block(
+def find_tokens_in_anno_block(
     anno: Dict, page_token_data: List[Page]
 ) -> List[Tuple[int, int]]:
     """Given the annotated block, and page tokens, search for tokens within that block.
     Used for searching text from free-form annotations.
+    TODO: This function ideally should be done in the UI rather than the cli. We need to
+    update this function in the future. 
 
     Returns:
         List[Tuple[int, int]]: [description]
     """
     tokens = page_token_data[anno["page"]].filter_tokens_by(
-        Block.from_anno(anno), soft_margin=dict(left=2, top=2, bottom=2, right=2)
+        Block.from_annotation(anno), soft_margin=dict(left=2, top=2, bottom=2, right=2)
     )
     return [(anno["page"], tid) for tid in tokens.keys()]
 
@@ -287,7 +289,7 @@ class TokenTableBuilder:
 
                 # Try to find the tokens if they are in free-form annotation mode
                 if anno["tokens"] is None:
-                    anno_token_indices = try_find_tokens_in_anno_block(
+                    anno_token_indices = find_tokens_in_anno_block(
                         anno, page_token_data
                     )
 

--- a/cli/pawls/commands/export.py
+++ b/cli/pawls/commands/export.py
@@ -15,6 +15,7 @@ from pawls.commands.utils import (
     AnnotationFolder,
     AnnotationFiles,
 )
+from pawls.preprocessors.model import *
 
 ALL_SUPPORTED_EXPORT_TYPE = ["coco", "token"]
 
@@ -22,6 +23,21 @@ ALL_SUPPORTED_EXPORT_TYPE = ["coco", "token"]
 def _convert_bounds_to_coco_bbox(bounds: Dict[str, Union[int, float]]):
     x1, y1, x2, y2 = bounds["left"], bounds["top"], bounds["right"], bounds["bottom"]
     return x1, y1, x2 - x1, y2 - y1
+
+
+def try_find_tokens_in_anno_block(
+    anno: Dict, page_token_data: List[Page]
+) -> List[Tuple[int, int]]:
+    """Given the annotated block, and page tokens, search for tokens within that block.
+    Used for searching text from free-form annotations.
+
+    Returns:
+        List[Tuple[int, int]]: [description]
+    """
+    tokens = page_token_data[anno["page"]].filter_tokens_by(
+        Block.from_anno(anno), soft_margin=dict(left=2, top=2, bottom=2, right=2)
+    )
+    return [(anno["page"], tid) for tid in tokens.keys()]
 
 
 class COCOBuilder:
@@ -223,12 +239,13 @@ class TokenTableBuilder:
 
     def create_paper_data(self, annotation_folder: AnnotationFolder):
 
+        all_page_token_df = {}
         all_page_token_data = {}
+
         for pdf in annotation_folder.all_pdfs:
             all_page_tokens = annotation_folder.get_pdf_tokens(pdf)
-
             # Get page token data
-            page_token_data = []
+            page_token_dfs = []
             for page_tokens in all_page_tokens:
                 token_data = [
                     (page_tokens.page.index, idx, token.text)
@@ -236,49 +253,61 @@ class TokenTableBuilder:
                 ]
                 df = pd.DataFrame(token_data, columns=["page_index", "index", "text"])
                 df = df.set_index(["page_index", "index"])
-                page_token_data.append(df)
-            page_token_data = pd.concat(page_token_data)
+                page_token_dfs.append(df)
 
-            all_page_token_data[get_pdf_sha(pdf)] = page_token_data
+            page_token_dfs = pd.concat(page_token_dfs)
 
+            all_page_token_df[get_pdf_sha(pdf)] = page_token_dfs
+            all_page_token_data[get_pdf_sha(pdf)] = all_page_tokens
+
+        self.all_page_token_df = all_page_token_df
         self.all_page_token_data = all_page_token_data
 
     def create_annotation_for_annotator(self, anno_files: AnnotationFiles) -> None:
 
         # Firstly initialize the annotation tables with the annotator name
         annotator = anno_files.annotator
-        for token_data in self.all_page_token_data.values():
+        for token_data in self.all_page_token_df.values():
             token_data[annotator] = None
 
         pbar = tqdm(anno_files)
 
         for anno_file in pbar:
             paper_sha = anno_file["paper_sha"]
-            df = self.all_page_token_data[paper_sha]
+            df = self.all_page_token_df[paper_sha]
+            page_token_data = self.all_page_token_data[paper_sha]
 
             pawls_annotations = load_json(anno_file["annotation_path"])["annotations"]
             for anno in pawls_annotations:
-                if anno["tokens"] is None:
-                    continue
 
                 # Skip if current category is not in the specified categories
                 label = anno["label"]["text"]
                 if label not in self.categories:
                     continue
 
-                anno_token_indices = [
-                    (ele["pageIndex"], ele["tokenIndex"]) for ele in anno["tokens"]
-                ]
+                # Try to find the tokens if they are in free-form annotation mode
+                if anno["tokens"] is None:
+                    anno_token_indices = try_find_tokens_in_anno_block(
+                        anno, page_token_data
+                    )
+
+                    if len(anno_token_indices) == 0:
+                        continue
+
+                else:
+                    anno_token_indices = [
+                        (ele["pageIndex"], ele["tokenIndex"]) for ele in anno["tokens"]
+                    ]
 
                 df.loc[anno_token_indices, annotator] = label
 
     def export(self):
 
-        for pdf, df in self.all_page_token_data.items():
+        for pdf, df in self.all_page_token_df.items():
             df["pdf"] = pdf
 
         df = (
-            pd.concat(self.all_page_token_data.values())
+            pd.concat(self.all_page_token_df.values())
             .reset_index()
             .set_index(["pdf", "page_index", "index"])
         )

--- a/cli/pawls/commands/metric.py
+++ b/cli/pawls/commands/metric.py
@@ -238,7 +238,7 @@ class TokenEvaluator:
         self, annotator_gt: str, annotator_pred: str
     ):
 
-        cur_df = self.df[[annotator_gt, annotator_pred]].fillna(-1)
+        cur_df = self.df[[annotator_gt, annotator_pred]].dropna(subset=[annotator_gt]).fillna(-1)
         acc = (cur_df[annotator_gt] == cur_df[annotator_pred]).mean()
 
         return acc

--- a/cli/pawls/commands/metric.py
+++ b/cli/pawls/commands/metric.py
@@ -234,23 +234,23 @@ class TokenEvaluator:
         # Assuming all users are stored in email address
 
     def calculate_scores_for_two_annotators(
-        self, annotator_gt: str, annotator_pred: str
+        self, ground_truth: str, predictions: str
     ):
 
         cur_df = (
-            self.df[[annotator_gt, annotator_pred]]
-            .dropna(subset=[annotator_gt])
+            self.df[[ground_truth, predictions]]
+            .dropna(subset=[ground_truth])
             .fillna(-1)
         )
-        acc = (cur_df[annotator_gt] == cur_df[annotator_pred]).mean()
+        acc = (cur_df[ground_truth] == cur_df[predictions]).mean()
 
         return acc
 
     def create_categorical_report(
-        self, annotator_gt: str, annotator_pred: str, table_per_category: dict
+        self, ground_truth: str, predictions: str, table_per_category: dict
     ):
-        gt = self.df[annotator_gt].fillna("").values
-        pred = self.df[annotator_pred].fillna("").values
+        gt = self.df[ground_truth].fillna("").values
+        pred = self.df[predictions].fillna("").values
         labels = list(table_per_category.keys())
 
         report = classification_report(
@@ -258,21 +258,21 @@ class TokenEvaluator:
         )
 
         for cat_name, table in table_per_category.items():
-            table[annotator_gt][annotator_pred] = report[cat_name]["f1-score"]
+            table[ground_truth][predictions] = report[cat_name]["f1-score"]
 
     def calculate_token_accuracy(self, categories: List = None):
         table = defaultdict(dict)
 
-        for i, annotator_gt in enumerate(self.annotators):
-            for j, annotator_pred in enumerate(self.annotators):
+        for i, ground_truth in enumerate(self.annotators):
+            for j, predictions in enumerate(self.annotators):
 
                 if i == j:
                     continue
                 # The token_acc table is symmetric
-                table[annotator_gt][
-                    annotator_pred
+                table[ground_truth][
+                    predictions
                 ] = self.calculate_scores_for_two_annotators(
-                    annotator_gt, annotator_pred
+                    ground_truth, predictions
                 )
 
         if categories is None:
@@ -280,12 +280,12 @@ class TokenEvaluator:
 
         table_per_category = {cat_name: defaultdict(dict) for cat_name in categories}
 
-        for i, annotator_gt in enumerate(self.annotators):
-            for j, annotator_pred in enumerate(self.annotators):
+        for i, ground_truth in enumerate(self.annotators):
+            for j, predictions in enumerate(self.annotators):
                 if i == j:
                     continue
                 self.create_categorical_report(
-                    annotator_gt, annotator_pred, table_per_category
+                    ground_truth, predictions, table_per_category
                 )
 
         return table, table_per_category

--- a/cli/pawls/preprocessors/model.py
+++ b/cli/pawls/preprocessors/model.py
@@ -128,7 +128,7 @@ class Block(Box):
     label: str
 
     @classmethod
-    def from_anno(cls, anno) -> "Box":
+    def from_annotation(cls, anno) -> "Box":
         """Create a box based on the given annotation."""
         bounds = anno["bounds"]
         return cls(

--- a/cli/pawls/preprocessors/model.py
+++ b/cli/pawls/preprocessors/model.py
@@ -107,6 +107,16 @@ class Box:
             "bottom": self.y + self.height,
         }
 
+    @classmethod
+    def from_bounds(cls, bounds) -> "Box":
+        """Create a box based on the given bounds."""
+        return cls(
+            x=bounds["left"],
+            y=bounds["top"],
+            width=bounds["right"] - bounds["left"],
+            height=bounds["bottom"] - bounds["top"],
+        )
+
 
 @dataclass
 class Token(Box):
@@ -116,6 +126,18 @@ class Token(Box):
 @dataclass
 class Block(Box):
     label: str
+
+    @classmethod
+    def from_anno(cls, anno) -> "Box":
+        """Create a box based on the given annotation."""
+        bounds = anno["bounds"]
+        return cls(
+            x=bounds["left"],
+            y=bounds["top"],
+            width=bounds["right"] - bounds["left"],
+            height=bounds["bottom"] - bounds["top"],
+            label=anno["label"]["text"],
+        )
 
 
 @dataclass


### PR DESCRIPTION
1. Select contatining tokens for free-form annotations and add in the outputs 
2. Better token accuracy report: 
    1. Only compute the scores for labeled tokens 
    2. Enable generating per-category token-level f1 scores 