### PR TITLE
Allow specifying pdf-shas for `export` and `metric` 

### DIFF
--- a/cli/pawls/commands/export.py
+++ b/cli/pawls/commands/export.py
@@ -250,10 +250,10 @@ class TokenTableBuilder:
             page_token_dfs = []
             for page_tokens in all_page_tokens:
                 token_data = [
-                    (page_tokens.page.index, idx, token.text)
+                    (page_tokens.page.index, idx, token.text, *token.coordinates)
                     for idx, token in enumerate(page_tokens.tokens)
                 ]
-                df = pd.DataFrame(token_data, columns=["page_index", "index", "text"])
+                df = pd.DataFrame(token_data, columns=["page_index", "index", "text", "x1", "y1", "x2", "y2"])
                 df = df.set_index(["page_index", "index"])
                 page_token_dfs.append(df)
 

--- a/cli/pawls/commands/export.py
+++ b/cli/pawls/commands/export.py
@@ -336,6 +336,12 @@ class TokenTableBuilder:
     help="Export specified categories in the annotations.",
 )
 @click.option(
+    "--pdf-shas",
+    multiple=True,
+    default=[],
+    help="Specify only exporting the selected PDF shas.",
+)
+@click.option(
     "--include-unfinished",
     "-i",
     is_flag=True,
@@ -353,6 +359,7 @@ def export(
     format: str,
     annotator: List,
     categories: List,
+    pdf_shas: List,
     include_unfinished: bool = False,
     export_images: bool = True,
 ):
@@ -374,8 +381,13 @@ def export(
     ), f"Invalid export format {format}. Should be one of {ALL_SUPPORTED_EXPORT_TYPE}."
     print(f"Export the annotations to the {format} format.")
 
+    if len(pdf_shas) != 0:
+        print(f"Export annotations from the following PDFs {pdf_shas}")
+    else:
+        pdf_shas = None
+
     config = LabelingConfiguration(config)
-    annotation_folder = AnnotationFolder(path)
+    annotation_folder = AnnotationFolder(path, pdf_shas=pdf_shas)
 
     if len(annotator) == 0:
         all_annotators = annotation_folder.all_annotators
@@ -388,7 +400,7 @@ def export(
         print(f"Export annotations from all available categories {categories}")
     else:
         print(f"Export annotations from the following categories {categories}")
-        
+
     if format == "coco":
 
         coco_builder = COCOBuilder(categories, output)
@@ -398,7 +410,7 @@ def export(
         for annotator in all_annotators:
             print(f"Export annotations from annotators {annotator}")
 
-            anno_files = AnnotationFiles(path, annotator, include_unfinished)
+            anno_files = AnnotationFiles(path, annotator, include_unfinished, pdf_shas)
 
             coco_builder.build_annotations(anno_files)
 
@@ -418,7 +430,7 @@ def export(
         for annotator in all_annotators:
 
             # print(f"Export annotations from annotators {annotator}")
-            anno_files = AnnotationFiles(path, annotator, include_unfinished)
+            anno_files = AnnotationFiles(path, annotator, include_unfinished, pdf_shas)
             token_builder.create_annotation_for_annotator(anno_files)
 
         df = token_builder.export()

--- a/cli/pawls/commands/metric.py
+++ b/cli/pawls/commands/metric.py
@@ -336,6 +336,12 @@ class TokenEvaluator:
     help="The annotations of non-textual categories will be evaluated based on AP scores based on box overlapping.",
 )
 @click.option(
+    "--pdf-shas",
+    multiple=True,
+    default=[],
+    help="Specify only exporting the selected PDF shas.",
+)
+@click.option(
     "--include-unfinished",
     "-i",
     is_flag=True,
@@ -360,6 +366,7 @@ def metric(
     annotator: List,
     textual_categories: List = [],
     non_textual_categories: List = [],
+    pdf_shas: List = [],
     include_unfinished: bool = False,
     verbose: bool = False,
     save: click.Path = None,
@@ -396,6 +403,7 @@ def metric(
         format=format,
         annotator=annotator,
         categories=categories,
+        pdf_shas=pdf_shas,
         include_unfinished=include_unfinished,
         export_images=False,
     )

--- a/cli/pawls/commands/utils.py
+++ b/cli/pawls/commands/utils.py
@@ -97,7 +97,7 @@ class AnnotationFolder:
             os.path.splitext(e)[0] for e in os.listdir(f"{self.path}/status")
         ]
 
-    def get_pdf_tokens(self, pdf_name: str) -> str:
+    def get_pdf_tokens(self, pdf_name: str) -> List["Page"]:
         """Get the pdf tokens for a pdf name by loading from the corresponding pdf_structure file.
 
         Args:

--- a/cli/pawls/preprocessors/pdfplumber.py
+++ b/cli/pawls/preprocessors/pdfplumber.py
@@ -68,7 +68,9 @@ class PDFPlumberTokenExtractor:
             vertical_ttb=True,
             extra_attrs=["fontname", "size"],
         )
-
+        if len(words) == 0:
+            return []
+            
         df = pd.DataFrame(words)
 
         # Avoid boxes outside the page


### PR DESCRIPTION
Now supports `pawls export xxxx --pdf-shas <pdf-sha1> --pdf-shas <pdf-sha2>` and `pawls metric xxxx --pdf-shas <pdf-sha1> --pdf-shas <pdf-sha2>`. This is especially useful when calculating IAA scores for a subset of the annotated dataset. 