### PR TITLE
Re #123; Update to Node 14.

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -2,7 +2,7 @@
 # environment where the JavaScript build process can run. In production the
 # files built by this process are served from disk, while in development a HTTP
 # server that's distributed with the UI build tools is used.
-FROM node:10.15.2
+FROM node:14
 
 # Setup a spot for our code
 WORKDIR /usr/local/src/skiff/app/ui


### PR DESCRIPTION
This upgrades the UI to use Node 14 instead of Node 10, which reaches
its EOL in 3 days. Node 14 is the current LTS release, though that
might shift soonish to Node 16.