### PR TITLE
Add troubleshooting section into readme, add self-healing option for eol endings

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The application was developed for Linux, and might fail to start on Windows beca
 To fix this, run this command from the root of the repository:
 
 ```bash
-~ (cd ./ui && yarn && yarn lint:fix) # with brackets, to stay in same directory
+~ (cd ./ui && yarn && yarn lint:fix) # with parenthesis, to stay in same directory
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -186,7 +186,9 @@ If you find PAWLS helpful for your research, please consider cite PAWLS.
 
 #### Windows EOL format (CRLF) vs Linux (LF)
 
-Sometimes you may wondering why building docker image is not working and `ui` part is taking down. It's because some files were saved in incorrect format. To healing such files just go to the repo's root and paste following in terminal.
+The application was developed for Linux, and might fail to start on Windows because of line-ending differences.
+
+To fix this, run this command from the root of the repository:
 
 ```bash
 ~ (cd ./ui && yarn && yarn lint:fix) # with brackets, to stay in same directory

--- a/README.md
+++ b/README.md
@@ -182,6 +182,16 @@ If you find PAWLS helpful for your research, please consider cite PAWLS.
 }
 ```
 
+### Troubleshooting
+
+1. Windows EOL format (CRLF) vs Linux (LF)
+
+Sometimes you may wondering why building docker image is not working and `ui` part is taking down. It's because some files were saved in incorrect format. To healing such files just go to the repo's root and paste following in terminal.
+
+```bash
+~ (cd ./ui && yarn lint:fix) # with brackets, to stay in same directory
+```
+
 ---
 
 PAWLS is an open-source project developed by [the Allen Institute for Artificial Intelligence (AI2)](http://www.allenai.org). AI2 is a non-profit institute with the mission to contribute to humanity through high-impact AI research and engineering.

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ If you find PAWLS helpful for your research, please consider cite PAWLS.
 Sometimes you may wondering why building docker image is not working and `ui` part is taking down. It's because some files were saved in incorrect format. To healing such files just go to the repo's root and paste following in terminal.
 
 ```bash
-~ (cd ./ui && yarn lint:fix) # with brackets, to stay in same directory
+~ (cd ./ui && yarn && yarn lint:fix) # with brackets, to stay in same directory
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ If you find PAWLS helpful for your research, please consider cite PAWLS.
 
 ### Troubleshooting
 
-1. Windows EOL format (CRLF) vs Linux (LF)
+#### Windows EOL format (CRLF) vs Linux (LF)
 
 Sometimes you may wondering why building docker image is not working and `ui` part is taking down. It's because some files were saved in incorrect format. To healing such files just go to the repo's root and paste following in terminal.
 

--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -1,3 +1,6 @@
 module.exports = {
     extends: ['@allenai/eslint-config-varnish'],
+    rules: {
+        'eol-last': ['error', 'always'],
+    },
 };

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -22,7 +22,7 @@ const RedirectToFirstPaper = () => {
     useEffect(() => {
         getAllocatedPaperStatus().then((allocation) => {
             const first = allocation.papers[0];
-            setSha(first.sha);
+            if (first) setSha(first.sha);
         });
     }, []);
 


### PR DESCRIPTION
Sometimes, building docker container on windows stops working, because of wrong file endings. And because ui is only part of that repository, it's not good enough to configure git hooks or something similar. 

So I suppose, providing self healing option to fix wrong file, is enough to get started quickly.  