### PR TITLE
Add a Dockerfile specific for local use.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,9 @@ services:
             - LOG_LEVEL=DEBUG
         command: ["main:app", "--host", "0.0.0.0", "--reload"]
     ui:
-        build: ./ui
+        build:
+          context: ./ui
+          dockerfile: Dockerfile-local
         # We can't mount the entire UI directory, since JavaScript dependencies
         # (`node_modules`) live at that location.
         volumes:

--- a/ui/Dockerfile-local
+++ b/ui/Dockerfile-local
@@ -1,0 +1,29 @@
+# NOTE: This Dockerfile is only used in development. It provides a runtime
+# environment where the JavaScript build process can run. In production the
+# files built by this process are served from disk, while in development a HTTP
+# server that's distributed with the UI build tools is used.
+FROM node:14
+
+# Setup a spot for our code
+WORKDIR /usr/local/src/skiff/app/ui
+
+# Install dependencies
+COPY package.json yarn.lock ./
+RUN yarn install
+
+# Copy in the source code
+COPY . .
+
+# This tells build scripts and libraries that we're in development, so they
+# can include stuff that's helpful for debugging even if it's a tad slower.
+ARG NODE_ENV=development
+ENV NODE_ENV $NODE_ENV
+ARG BABEL_ENV=development
+ENV BABEL_ENV $BABEL_ENV
+
+# Tell `react-scripts` that it's not supposed to open a browser for us, since
+# it's not running on the host machine.
+ENV BROWSER none
+
+ENTRYPOINT [ "yarn" ]
+CMD [ "start" ]


### PR DESCRIPTION
This adds a `Dockerfile`, named `Dockerfile-local` that's used
when running a local version of the code.

The only difference in this file is that it omits the `yarn build`
command. This:

1. Makes things faster. A build will be executed when the local
   application server starts, which is duplicative. After this
   change this will only happen once.
2. Formatting errors won't cause the stack to fail to start. The
   UI will still display the error message until it's resolved,
   but the container will still start so that resolution can be
   done without rerunning `docker compose up`.