### PR TITLE
Adjust README wording to make first steps clearer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ### Quick Start
 
-*Quick start will download some pre-processed PDFs and get the UI set up so that you can see them. If you want to pre-process your own pdfs, keep reading! If it's your first time working with PAWLS, we recommend you try the quick start first though.*
+*Quick start will download some pre-processed PDFs and get the UI set up so that you can see them. If you want to pre-process your own PDFs, keep reading! If it's your first time working with PAWLS, we recommend you try the quick start first though.*
 
 First, we need to download some processed PDFs to view in the UI. PAWLS uses the PDFs themselves to render in the browser, as well as using a JSON file of extracted token bounding boxes per page, called `pdf_structure.json`. The [PAWLS CLI](cli/readme.md) can be used to do this pre-processing, but for the quick start, we have done it for you. Download them from the provided AWS S3 Bucket like so:
 
@@ -19,7 +19,7 @@ First, we need to download some processed PDFs to view in the UI. PAWLS uses the
 aws s3 sync s3://ai2-s2-pawls-public/example-data ./skiff_files/apps/pawls/papers/
 ```
 
-Configuration in PAWLS is controlled by a json file, located in the [`api/config`](./api/config/configuration.json) directory. The location that we downloaded the pdfs to above corresponds to the location in the config file, where it is mounted in using [`docker-compose.yaml`](./docker-compose.yaml). So, when PAWLS starts up, the API knows where to look to serve the PDFs we want.
+Configuration in PAWLS is controlled by a JSON file, located in the [`api/config`](./api/config/configuration.json) directory. The location that we downloaded the PDFs to above corresponds to the location in the config file, where it is mounted in using [`docker-compose.yaml`](./docker-compose.yaml). So, when PAWLS starts up, the API knows where to look to serve the PDFs we want.
 
 Next, we can start the services required to use PAWLS using `docker-compose`:
 
@@ -40,12 +40,12 @@ Once all of these have come up, navigate to `localhost:8080` in your browser and
 
 ### Getting Started
 
-In order to run a local environment, you'll need to use the [PAWLS CLI](cli/readme.md) to download the PDFs and metadata you want to serve. The PDFs should be put in `skiff_files/apps/pawls`.
+In order to run a local environment, you'll need to use the [PAWLS CLI](cli/readme.md) to preprocess and assign the PDFs you want to serve. When using PDFs from semantic scholar, the CLI is also used to download the PDFs. The PDFs have to be put in a directory structure within `skiff_files/apps/pawls` (see [PAWLS CLI usage](cli/readme.md#usage) for details).
 
-For instance, you can run this command to download the specified PDF:
+For instance, you can run the following commands to download, preprocess, and assign PDFs:
 
 ```bash
-  # Fetches pdfs from semantic scholar's S3 buckets.
+  # Fetches PDFs from semantic scholar's S3 buckets.
   python scripts/ai2-internal/fetch_pdfs.py skiff_files/apps/pawls/papers 34f25a8704614163c4095b3ee2fc969b60de4698 3febb2bed8865945e7fddc99efd791887bb7e14f 553c58a05e25f794d24e8db8c2b8fdb9603e6a29
   # ensure that the papers are pre-processed with grobid so that they have token information.
   pawls preprocess grobid skiff_files/apps/pawls/papers

--- a/cli/readme.md
+++ b/cli/readme.md
@@ -19,7 +19,7 @@ Please follow the [instructions here](https://tesseract-ocr.github.io/tessdoc/In
 
 ### Usage
 
-1. Download PDFs based on <PDF_SHA>s into the <SAVE_PATH> (e.g., `skiff_files/apps/pawls/papers` ). If you work at AI2, see the internal usage script for doing this [here](../../scripts/ai2-internal). Otherwise, pdfs are expected to be in a directory structure with a single pdf per folder, where each folder's name is a unique id corresponding to that pdf. For example:
+1. Place or download PDFs into `skiff_files/apps/pawls/papers` as described below. If you work at AI2, see the internal usage script for doing this [here](../../scripts/ai2-internal). Otherwise, PDFs are expected to be in a directory structure with a single PDF per folder, where each folder's name is a unique ID corresponding to that PDF. For example:
 ```
     top_level/
     ├───pdf1/
@@ -27,7 +27,7 @@ Please follow the [instructions here](https://tesseract-ocr.github.io/tessdoc/In
     └───pdf2/
           └───pdf2.pdf
 ```
-By default, pawls will use the name of the containing directory to refer to the pdf in the ui.
+By default, pawls will use the name of the containing directory to refer to the PDF in the UI.
 
 2. [preprocess] Process the token information for each PDF document with the given PDF preprocessor.
     ```bash
@@ -43,8 +43,8 @@ By default, pawls will use the name of the containing directory to refer to the 
     pawls assign ./skiff_files/apps/pawls/papers <user> <PDF_SHA>
     ```
     Optionally at this stage, you can provide a `--name-file` argument to `pawls assign`,
-    which allows you to specify a name for a given pdf (for example the title of a paper).
-    This file should be a json file containing `sha:name` mappings.
+    which allows you to specify a name for a given PDF (for example the title of a paper).
+    This file should be a JSON file containing `sha:name` mappings.
 
 4. (optional) [preannotate] Create pre-annotations for the PDFs based on some model predictions `anno.json`:
     ```bash


### PR DESCRIPTION
I found the process of getting started (especially with my own PDFs) somewhat confusing based on the README ([see Issue](https://github.com/allenai/pawls/issues/135#issuecomment-892457244) for details).

Here's an attempt to make some of the wording more clear.