### PR TITLE
make lint fix work on windows

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -5,8 +5,8 @@
   "license": "UNLICENSED",
   "private": true,
   "scripts": {
-    "lint": "eslint '**/*.{js,ts,tsx,json}' && echo 'Lint complete.'",
-    "lint:fix": "eslint '**/*.{js,ts,tsx,json}' --fix && echo 'Lint --fix complete.'",
+    "lint": "eslint src/**/*.{js,ts,tsx,json} && echo 'Lint complete.'",
+    "lint:fix": "eslint src/**/*.{js,ts,tsx,json} --fix && echo 'Lint --fix complete.'",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test"


### PR DESCRIPTION
Linter did not work for me. Single quotes '' made eslint find no files. I also changed it to look in src. Otherwise it was looking also in node_modules and it took forever to complete