### PR TITLE
Adding a CLI tool for adding PDFs

### DIFF
--- a/cli/pawls/__main__.py
+++ b/cli/pawls/__main__.py
@@ -20,7 +20,8 @@ subcommands = [
     commands.export,
     commands.status,
     commands.preannotate,
-    commands.metric
+    commands.metric,
+    commands.add
 ]
 
 for subcommand in subcommands:

--- a/cli/pawls/commands/__init__.py
+++ b/cli/pawls/commands/__init__.py
@@ -4,3 +4,4 @@ from pawls.commands.assign import assign
 from pawls.commands.export import export
 from pawls.commands.status import status
 from pawls.commands.metric import metric
+from pawls.commands.dataset import add

--- a/cli/pawls/commands/dataset.py
+++ b/cli/pawls/commands/dataset.py
@@ -3,6 +3,7 @@ import glob
 import click
 import shutil
 import hashlib
+import logging
 
 from tqdm import tqdm
 from pathlib import Path
@@ -28,24 +29,36 @@ def copy(source: Union[str, Path], destination: Union[str, Path]) -> None:
 
 @click.command(context_settings={"help_option_names": ["--help", "-h"]})
 @click.argument("directory", type=click.Path(exists=True, file_okay=True, dir_okay=True))
-def add(directory: click.Path) -> None:
+@click.option("--no-hash", is_flag=True)
+def add(directory: click.Path, no_hash: bool) -> None:
     """
     Add a PDF or directory of PDFs to the pawls dataset (skiff_files/).
     """
-    base_dir = Path('skiff_files/apps/pawls/papers')
+    base_dir = Path("skiff_files/apps/pawls/papers")
     base_dir.mkdir(exist_ok=True, parents=True)
 
     if os.path.isdir(str(directory)):
-        pdfs = glob.glob(os.path.join(str(directory), '*.pdf'))
+        pdfs = glob.glob(os.path.join(str(directory), "*.pdf"))
     else:
         pdfs = [str(directory)]
 
-    print(f'Found {len(pdfs)} total PDFs to add.')
+    logging.info(f"Found {len(pdfs)} total PDFs to add.")
 
     for pdf in tqdm(pdfs):
-        sha = hash_pdf(pdf)
+        pdf_name = Path(pdf).stem
 
-        output_dir = base_dir / sha
+        if not no_hash:
+            pdf_name = hash_pdf(pdf)
+
+        output_dir = base_dir / pdf_name
+
+        if output_dir.exists() and no_hash:
+            logging.warning(f"PDF with name {pdf_name}.pdf already added. Skipping...")
+            continue
+        elif output_dir.exists():
+            logging.warning(f"{pdf} already added. Skipping...")
+            continue
+
         output_dir.mkdir(exist_ok=True)
 
-        copy(pdf, output_dir / (sha + '.pdf'))
+        copy(pdf, output_dir / (pdf_name + '.pdf'))

--- a/cli/pawls/commands/dataset.py
+++ b/cli/pawls/commands/dataset.py
@@ -1,0 +1,51 @@
+import os
+import glob
+import click
+import shutil
+import hashlib
+
+from tqdm import tqdm
+from pathlib import Path
+from typing import Union
+
+
+def hash_pdf(file: Union[str, Path]) -> str:
+    block_size = 65536
+
+    file_hash = hashlib.sha256()
+    with open(str(file), 'rb') as fp:
+        fb = fp.read(block_size)
+        while len(fb) > 0:
+            file_hash.update(fb)
+            fb = fp.read(block_size)
+
+    return str(file_hash.hexdigest())
+
+
+def copy(source: Union[str, Path], destination: Union[str, Path]) -> None:
+    shutil.copy(str(source), str(destination))
+
+
+@click.command(context_settings={"help_option_names": ["--help", "-h"]})
+@click.argument("directory", type=click.Path(exists=True, file_okay=True, dir_okay=True))
+def add(directory: click.Path) -> None:
+    """
+    Add a PDF or directory of PDFs to the pawls dataset (skiff_files/).
+    """
+    base_dir = Path('skiff_files/apps/pawls/papers')
+    base_dir.mkdir(exist_ok=True, parents=True)
+
+    if os.path.isdir(str(directory)):
+        pdfs = glob.glob(os.path.join(str(directory), '*.pdf'))
+    else:
+        pdfs = [str(directory)]
+
+    print(f'Found {len(pdfs)} total PDFs to add.')
+
+    for pdf in tqdm(pdfs):
+        sha = hash_pdf(pdf)
+
+        output_dir = base_dir / sha
+        output_dir.mkdir(exist_ok=True)
+
+        copy(pdf, output_dir / (sha + '.pdf'))

--- a/cli/readme.md
+++ b/cli/readme.md
@@ -19,15 +19,15 @@ Please follow the [instructions here](https://tesseract-ocr.github.io/tessdoc/In
 
 ### Usage
 
-1. Place or download PDFs into `skiff_files/apps/pawls/papers` as described below. If you work at AI2, see the internal usage script for doing this [here](../../scripts/ai2-internal). Otherwise, PDFs are expected to be in a directory structure with a single PDF per folder, where each folder's name is a unique ID corresponding to that PDF. For example:
+1. Place or download PDFs into `skiff_files/apps/pawls/papers` as described below. If you work at AI2, see the internal usage script for doing this [here](../../scripts/ai2-internal). 
+
+Otherwise, you can add PDFs using the command:
+```bash
+pawls add <pdf-or-directory>
 ```
-    top_level/
-    ├───pdf1/
-    │     └───pdf1.pdf
-    └───pdf2/
-          └───pdf2.pdf
-```
-By default, pawls will use the name of the containing directory to refer to the PDF in the UI.
+
+By default, pawls will create a unique id per PDF by hashing the PDF, and use that hash to refer to the PDF in the UI.
+You can instead retain the original PDF name by passing the `--no-hash` flag to `pawls add`.
 
 2. [preprocess] Process the token information for each PDF document with the given PDF preprocessor.
     ```bash
@@ -113,3 +113,16 @@ By default, pawls will use the name of the containing directory to refer to the 
         ```bash
         pawls export <labeling_folder> <labeling_config> <output_path> <format> -u markn --include-unfinished
         ```
+
+## Dataset structure
+
+PDFs are expected to be in a directory structure with a single PDF per folder, where each folder's name is a unique ID corresponding to that PDF. For example:
+```
+    top_level/
+    ├───pdf1/
+    │     └───pdf1.pdf
+    └───pdf2/
+          └───pdf2.pdf
+```
+
+Using only `pawls add` to add PDFs will maintain this structure by default.


### PR DESCRIPTION
One thing I would appreciate in Pawls (and am happy to flesh out, if there's any interest) is an extended CLI that can manage datasets. As a quick first pass, I added a command that takes in a PDF or directory of PDFs and copies them into the `skiff_files` folder.

```
pawls add [PDF OR FOLDER OF PDFS]
```

It hashes the PDFs and copies them into `skiff_files`.

---

The rest is outside the scope of this pull request, but in general, I was thinking of a set of commands, to create a dataset:

```
pawls dataset create [DATASET NAME] [INITIAL PDFS]
```
Add pdfs to the dataset:

```
pawls dataset add [PDFS]
```

And offer per-dataset configuration for the label-set.