### PR TITLE
Make the path splitting by the PAWLS CLI platform independent

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -85,7 +85,7 @@ def user_is_allowed(user_email: str) -> bool:
 
 def all_pdf_shas() -> List[str]:
     pdfs = glob.glob(f"{configuration.output_directory}/*/*.pdf")
-    return [p.split("/")[-2] for p in pdfs]
+    return [os.path.split(p)[-2] for p in pdfs]
 
 
 def update_status_json(status_path: str, sha: str, data: Dict[str, Any]):

--- a/cli/pawls/commands/assign.py
+++ b/cli/pawls/commands/assign.py
@@ -60,7 +60,7 @@ def assign(
     shas = set(shas)
 
     pdfs = glob.glob(os.path.join(path, "*/*.pdf"))
-    project_shas = {p.split("/")[-2] for p in pdfs}
+    project_shas = {os.path.split(p)[-2] for p in pdfs}
     if all:
         # If --all flag, we use all pdfs in the current project.
         shas.update(project_shas)

--- a/cli/pawls/commands/metric.py
+++ b/cli/pawls/commands/metric.py
@@ -93,7 +93,7 @@ class COCOEvaluator:
         annotators = []
         for userfile in sorted(glob(f"{coco_save_path}/*.json")):
             with HiddenPrints():
-                username = userfile.split("/")[-1].replace(".json", "")
+                username = os.path.split(userfile)[-1].replace(".json", "")
                 annotators.append(username)
                 all_cocos[username] = COCO(userfile)
 

--- a/cli/pawls/commands/utils.py
+++ b/cli/pawls/commands/utils.py
@@ -83,7 +83,7 @@ class AnnotationFolder:
         self.all_pdf_paths = [pdf_path for pdf_path in glob(f"{self.path}/*/*.pdf")]
         if pdf_shas is not None:
             self.all_pdf_paths = [
-                ele for ele in self.all_pdf_paths if ele.split("/")[-2] in pdf_shas
+                ele for ele in self.all_pdf_paths if os.path.split(ele)[-2] in pdf_shas
             ]
         self.all_pdfs = [os.path.basename(pdf_path) for pdf_path in self.all_pdf_paths]
 
@@ -246,7 +246,7 @@ class AnnotationFiles:
         return [
             file
             for file in self.get_all_annotation_files()
-            if file.split("/")[-2] in pdf_shas
+            if os.path.split(file)[-2] in pdf_shas
         ]
 
     def get_finished_annotation_files(self) -> List[str]:
@@ -269,7 +269,7 @@ class AnnotationFiles:
     def __iter__(self) -> Iterable[Dict]:
 
         for _file in self._files:
-            pdf_sha = _file.split("/")[-2]
+            pdf_sha = os.path.split(_file)[-2]
             pdf_path = f"{self.labeling_folder}/{pdf_sha}/{pdf_sha}.pdf"
 
             yield dict(


### PR DESCRIPTION
Using this fix the `pawls assign` command also works on my Windows machine.