### PR TITLE
Added ocr lang config, psm and GCV support

### DIFF
--- a/cli/pawls/commands/preprocess.py
+++ b/cli/pawls/commands/preprocess.py
@@ -1,6 +1,8 @@
+from email.policy import default
 import os
 from pathlib import Path
 import json
+import re
 
 from tqdm import tqdm
 import click
@@ -8,12 +10,14 @@ import glob
 
 from pawls.preprocessors.grobid import process_grobid
 from pawls.preprocessors.pdfplumber import process_pdfplumber
-from pawls.preprocessors.tesseract import process_tesseract
+from pawls.preprocessors.tesseract import process_ocr
 
 @click.command(context_settings={"help_option_names": ["--help", "-h"]})
 @click.argument("preprocessor", type=str)
 @click.argument("path", type=click.Path(exists=True, file_okay=True, dir_okay=True))
-def preprocess(preprocessor: str, path: click.Path):
+@click.argument("ocr-param", nargs=-1)
+
+def preprocess(preprocessor: str, path: click.Path, ocr_param: tuple):
     """
     Run a pre-processor on a pdf/directory of pawls pdfs and
     write the resulting token information to the pdf location.
@@ -24,9 +28,25 @@ def preprocess(preprocessor: str, path: click.Path):
 
         `pawls preprocess grobid ./`
     """
+    
     print(f"Processing using the {preprocessor} preprocessor...")
+
+    ocr_args = {
+        "engine": "",
+        "lang": "",
+        "psm": ""
+    }
+
     if preprocessor == "ocr":
         print("The ocr preprocessor may take several minutes to process each PDF.")
+        if len(ocr_param) > 1:
+            for param in ocr_param[1:]:
+                if not re.search("\w+=\w+", param) :
+                    raise ValueError(f"There's an error in ocr_param option '{param}'. Parameters should be indicated as key=value.")
+                key, value = param.split("=", 1)
+                if key not in ocr_args.keys():
+                    raise ValueError(f"There's an unknown option '{key}=' in ocr_param options. Available options are engine, lang, psm and gcv_credential.")
+                ocr_args[key] = value
     if os.path.isdir(path):
         in_glob = os.path.join(path, "*/*.pdf")
         pdfs = glob.glob(in_glob)
@@ -46,9 +66,7 @@ def preprocess(preprocessor: str, path: click.Path):
         elif preprocessor == "pdfplumber":
             data = process_pdfplumber(str(path))
         elif preprocessor == "ocr":
-            # Currently there's only a OCR preprocessor. 
-            data = process_tesseract(str(path))
-        with open(path.parent / "pdf_structure.json", "w+") as f:
-
-            json.dump(data, f)
+            data = process_ocr(str(path), ocr_args)
+        with open(path.parent / "pdf_structure.json", "w+", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False)
 

--- a/cli/readme.md
+++ b/cli/readme.md
@@ -36,7 +36,7 @@ You can instead retain the original PDF name by passing the `--no-hash` flag to 
     Currently we support the following preprocessors:
     1. pdfplumber
     2. grobid *Note: to use the grobid preprocessor, you need to run `docker-compose up` in a separate shell, because grobid needs to be running as a service.*
-    3. ocr *Note: you might need to install [tesseract-ocr](https://tesseract-ocr.github.io/tessdoc/Installation.html) for using this preprocessor.*
+    3. ocr *Note: you might need to install [tesseract-ocr](https://tesseract-ocr.github.io/tessdoc/Installation.html) for using this preprocessor. It also accepts extra parameters for language and page segmentation mode (eg: `pawls preprocess ocr <path> ocr-param lang=eng+ara psm=11`). If you want to use Google Cloud Vision instead, you can run the command with `ocr-param engine=cloud-vision` and `lang="en+ar"` after downloading your credential file from GCP to `<current-working-dir>/gcv-*.json`.*
 
 3. [assign] Assign annotation tasks (<PDF_SHA>s) to specific users <user>:
     ```bash

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -23,3 +23,5 @@ pycocotools
 
 # Used for OCR
 pytesseract
+google-cloud-vision
+opencv-python


### PR DESCRIPTION
- Can choose between tesseract or Google Cloud Vision as an OCR engine (default to Tesseract)
- Can specify languages and page segmentation mode (psm only for tesseract, languages should be expressed in the appropriate format : [Tesseract ](https://tesseract-ocr.github.io/tessdoc/Data-Files-in-different-versions.html)/ [GCV](https://cloud.google.com/vision/docs/languages) langs refs)
- Can generate output with non-latin characters 