### PR TITLE
fix scikit package name in cli setup.py

### DIFF
--- a/cli/setup.py
+++ b/cli/setup.py
@@ -36,7 +36,7 @@ setup(
         "tabulate",
         "pycocotools",
         "cython",
-        "sklearn",
+        "scikit-learn",
     ],
     python_requires=">=3.6",
     entry_points={"console_scripts": ["pawls=pawls.__main__:pawls_cli"]},


### PR DESCRIPTION
out of date package name causes errors when installing, alternatively you can run:  `SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True python setup.py install`